### PR TITLE
fix: fix server prod warning log

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "nodemon",
     "build": "rimraf build && tsc",
-    "start": "npm run build && node build/server.js"
+    "start": "yarn build && node build/server.js"
   },
   "author": "Naing Linn Khant",
   "license": "ISC",


### PR DESCRIPTION
Fix "npm WARN config production Use `--omit=dev` instead."